### PR TITLE
fix bug where fixed header overflows into main container on landing page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -46,7 +46,7 @@ header nav ul li {
 
 .container {
     width: 1024px;
-    margin: 0 auto;
+    margin: 0 auto 100px;
 }
 
 /* each section in the container takes up 50% of width*/


### PR DESCRIPTION
Added margin to the top of the container to give room to fixed navigation header.